### PR TITLE
fix: Remove lombok annotations on domain classes

### DIFF
--- a/src/main/java/example/sequence/issue/PlanConstraintProvider.java
+++ b/src/main/java/example/sequence/issue/PlanConstraintProvider.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 
 public class PlanConstraintProvider implements ConstraintProvider {
 
-    public static final Comparator<Stock> STOCK_COMPARATOR = Comparator.comparing(Stock::getPeriod, Comparator.comparing(Period::getIndex));
+    public static final Comparator<Stock> STOCK_COMPARATOR = Comparator.comparing(Stock::getPeriod, Comparator.comparing(Period::index));
 
     @Override
     public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
@@ -41,7 +41,7 @@ public class PlanConstraintProvider implements ConstraintProvider {
                 .forEach(Job.class)
                 .filter(job -> job.getQuantity() <= 0)
                 .groupBy(Job::getProduct,
-                        ConstraintCollectors.toConsecutiveSequences(job -> job.getPeriod().getIndex()))
+                        ConstraintCollectors.toConsecutiveSequences(job -> job.getPeriod().index()))
                 .flattenLast(SequenceChain::getConsecutiveSequences)
 //                .filter((product, sequence) -> sequence.getCount() > 1)
                 .penalize(HardSoftLongScore.ONE_HARD, (product, sequence) -> sequence.getCount() -1)
@@ -53,7 +53,7 @@ public class PlanConstraintProvider implements ConstraintProvider {
                 .forEach(Stock.class)
                 .filter(stock -> stock.getQuantity() < 0)
                 .groupBy(Stock::getProduct,
-                        ConstraintCollectors.toConsecutiveSequences(stock -> stock.getPeriod().getIndex()))
+                        ConstraintCollectors.toConsecutiveSequences(stock -> stock.getPeriod().index()))
                 .flattenLast(SequenceChain::getConsecutiveSequences)
 //                .filter((product, sequence) -> sequence.getCount() > 1)
                 .penalize(HardSoftLongScore.ONE_HARD, (product, sequence) -> sequence.getCount() -1)

--- a/src/main/java/example/sequence/issue/bootstrap/SampleGenerator.java
+++ b/src/main/java/example/sequence/issue/bootstrap/SampleGenerator.java
@@ -2,6 +2,7 @@ package example.sequence.issue.bootstrap;
 
 import ai.timefold.solver.core.api.solver.SolverJob;
 import ai.timefold.solver.core.api.solver.SolverManager;
+
 import example.sequence.issue.model.Job;
 import example.sequence.issue.model.Period;
 import example.sequence.issue.model.Plan;
@@ -32,29 +33,35 @@ public class SampleGenerator {
     public void onApplicationEvent(ApplicationStartedEvent event) throws ExecutionException, InterruptedException {
         log.info("Generating plan...");
 
-        List<Period> periods = IntStream.rangeClosed(1, 4).mapToObj(index -> Period.builder().index(index).name("p" + index).build()).toList();
-        List<Product> products = IntStream.rangeClosed(1, 1).mapToObj(index -> Product.builder().name("product-" + index).build()).toList();
+        List<Period> periods = IntStream.rangeClosed(1, 4).mapToObj(index -> new Period(index, "p" + index)).toList();
+        List<Product> products = IntStream.rangeClosed(1, 1).mapToObj(index -> new Product("product-" + index)).toList();
 
         List<Job> jobs = new ArrayList<>();
         List<Stock> stocks = new ArrayList<>();
         for (Product product : products) {
             long demand = 0;
             for (Period period : periods) {
-                jobs.add(Job.builder().jobId(String.join("-", period.getName(), product.getName()))
-                        .period(period).product(product).build());
+                var job = new Job();
+                job.setJobId(period.name() + "-" + product.name());
+                job.setPeriod(period);
+                job.setProduct(product);
+                jobs.add(job);
                 demand += 10;
-                stocks.add(Stock.builder().stockId(String.join("-", period.getName(), product.getName())).period(period).product(product).quantity(-demand).build());
+
+                var stock = new Stock();
+                stock.setStockId(period.name() + "-" + product.name());
+                stock.setPeriod(period);
+                stock.setProduct(product);
+                stock.setQuantity(-demand);
+                stocks.add(stock);
             }
         }
 
-        Plan plan = Plan.builder()
-                .periods(periods)
-                .products(products)
-                .jobs(jobs)
-                .stocks(stocks)
-                .build();
-
-
+        Plan plan = new Plan();
+        plan.setPeriods(periods);
+        plan.setProducts(products);
+        plan.setJobs(jobs);
+        plan.setStocks(stocks);
         planRepository.write(plan);
 
         plan.getStocks().forEach(job -> log.info("Stock:: {}", job));

--- a/src/main/java/example/sequence/issue/model/Job.java
+++ b/src/main/java/example/sequence/issue/model/Job.java
@@ -11,23 +11,54 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
-@Data
-@Builder
 @PlanningEntity
-@AllArgsConstructor
-@NoArgsConstructor
 public class Job {
-
-    @ToString.Exclude
     private Product product;
-    @ToString.Exclude
     private Period period;
 
     @PlanningId
-    @EqualsAndHashCode.Include private String jobId;
+    private String jobId;
 
     @PlanningVariable(valueRangeProviderRefs = "quantities")
-    @Builder.Default
-    private Long quantity = 0L;
+    private Long quantity = null;
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public void setProduct(Product product) {
+        this.product = product;
+    }
+
+    public Period getPeriod() {
+        return period;
+    }
+
+    public void setPeriod(Period period) {
+        this.period = period;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(String jobId) {
+        this.jobId = jobId;
+    }
+
+    public Long getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Long quantity) {
+        this.quantity = quantity;
+    }
+
+    @Override
+    public String toString() {
+        return "Job{" +
+                "jobId='" + jobId + '\'' +
+                ", quantity=" + quantity +
+                '}';
+    }
 }

--- a/src/main/java/example/sequence/issue/model/Period.java
+++ b/src/main/java/example/sequence/issue/model/Period.java
@@ -3,9 +3,5 @@ package example.sequence.issue.model;
 import lombok.Builder;
 import lombok.Data;
 
-@Builder
-@Data
-public class Period {
-    private int index;
-    private String name;
+public record Period(int index, String name) {
 }

--- a/src/main/java/example/sequence/issue/model/Plan.java
+++ b/src/main/java/example/sequence/issue/model/Plan.java
@@ -17,18 +17,11 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 
 @PlanningSolution
-@Data
-@Builder
-@Slf4j
-@AllArgsConstructor
-@NoArgsConstructor
 public class Plan {
-
     private List<Period> periods;
     private List<Product> products;
 
     @ValueRangeProvider(id = "quantities")
-    @Builder.Default
     private CountableValueRange<Long> jobSizes = ValueRangeFactory.createLongValueRange(3, 35);
 
     @PlanningEntityCollectionProperty
@@ -39,4 +32,60 @@ public class Plan {
     @PlanningScore
     private HardSoftLongScore score;
 
+    public List<Period> getPeriods() {
+        return periods;
+    }
+
+    public void setPeriods(List<Period> periods) {
+        this.periods = periods;
+    }
+
+    public List<Product> getProducts() {
+        return products;
+    }
+
+    public void setProducts(List<Product> products) {
+        this.products = products;
+    }
+
+    public CountableValueRange<Long> getJobSizes() {
+        return jobSizes;
+    }
+
+    public void setJobSizes(CountableValueRange<Long> jobSizes) {
+        this.jobSizes = jobSizes;
+    }
+
+    public List<Job> getJobs() {
+        return jobs;
+    }
+
+    public void setJobs(List<Job> jobs) {
+        this.jobs = jobs;
+    }
+
+    public List<Stock> getStocks() {
+        return stocks;
+    }
+
+    public void setStocks(List<Stock> stocks) {
+        this.stocks = stocks;
+    }
+
+    public HardSoftLongScore getScore() {
+        return score;
+    }
+
+    public void setScore(HardSoftLongScore score) {
+        this.score = score;
+    }
+
+    @Override
+    public String toString() {
+        return "Plan{" +
+                "products=" + products +
+                ", stocks=" + stocks +
+                ", score=" + score +
+                '}';
+    }
 }

--- a/src/main/java/example/sequence/issue/model/Product.java
+++ b/src/main/java/example/sequence/issue/model/Product.java
@@ -3,8 +3,5 @@ package example.sequence.issue.model;
 import lombok.Builder;
 import lombok.Data;
 
-@Data
-@Builder
-public class Product {
-    private String name;
+public record Product(String name) {
 }

--- a/src/main/java/example/sequence/issue/model/Stock.java
+++ b/src/main/java/example/sequence/issue/model/Stock.java
@@ -12,23 +12,57 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-@Builder
-@Data
 @PlanningEntity
-@NoArgsConstructor
-@AllArgsConstructor
 public class Stock {
     @PlanningId
-    @EqualsAndHashCode.Include
     private String stockId;
 
-    @ToString.Exclude
     private Period period;
-    @ToString.Exclude
     private Product product;
+
     @ShadowVariable(
             sourceEntityClass = Job.class,
             sourceVariableName = "quantity",
             variableListenerClass = StockQuantityVariableListener.class)
     private Long quantity;
+
+    public String getStockId() {
+        return stockId;
+    }
+
+    public void setStockId(String stockId) {
+        this.stockId = stockId;
+    }
+
+    public Period getPeriod() {
+        return period;
+    }
+
+    public void setPeriod(Period period) {
+        this.period = period;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public void setProduct(Product product) {
+        this.product = product;
+    }
+
+    public Long getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Long quantity) {
+        this.quantity = quantity;
+    }
+
+    @Override
+    public String toString() {
+        return "Stock{" +
+                "stockId='" + stockId + '\'' +
+                ", quantity=" + quantity +
+                '}';
+    }
 }

--- a/src/main/java/example/sequence/issue/model/solver/StockQuantityVariableListener.java
+++ b/src/main/java/example/sequence/issue/model/solver/StockQuantityVariableListener.java
@@ -50,8 +50,8 @@ public class StockQuantityVariableListener implements VariableListener<Plan, Job
             ScoreDirector<Plan> scoreDirector, Product product, Period period) {
         return scoreDirector.getWorkingSolution().getStocks().stream()
                 .filter(stock -> stock.getProduct().equals(product))
-                .filter(stock -> stock.getPeriod().getIndex() >= period.getIndex())
-                .sorted(Comparator.comparing(stock -> stock.getPeriod().getIndex()))
+                .filter(stock -> stock.getPeriod().index() >= period.index())
+                .sorted(Comparator.comparing(stock -> stock.getPeriod().index()))
                 .toList();
     }
 


### PR DESCRIPTION
It appears the generated lombok code breaks the domain in some fundamental way. Made the code use records for facts and standard POJO getters/setters for the entities and solution.

Modified Job to default to a null quantity since 0 is not inside the value range. If you want 0 to be included:

- Add 0 to the value range.
- Make quantity a nullable variable.


`mvn spring-boot:run` no longer triggers an exception on `FULL_ASSERT`, and finishes with a valid solution:

```
Job:: Job{jobId='p1-product-1', quantity=30}
Job:: Job{jobId='p2-product-1', quantity=10}
Job:: Job{jobId='p3-product-1', quantity=3}
Job:: Job{jobId='p4-product-1', quantity=3}
```
